### PR TITLE
Fix auto responder state tracking

### DIFF
--- a/chrome_chat_agent.py
+++ b/chrome_chat_agent.py
@@ -47,6 +47,10 @@ AUTO_DOMAINS          = {
 _DEBUG_PORT = 9222
 _LOCK_HOST  = ""  # wird in connect_chrome gesetzt
 
+_last_sent_text: str = ""
+_last_sent_time: float = 0.0
+_ECHO_COOLDOWN_SEC = 10.0  # innerhalb dieses Fensters niemals auf eigenen Text antworten
+
 # -------------------- Transparenz-Hinweis ------------------------------------
 console.print("[bold red]⚠ Achtung:[/bold red] Diese Sitzung wird von einer [bold]AI[/bold] unterstützt.")
 console.print("Alle Aktionen im Chrome-Browser laufen über dieses Agent-Skript. Bitte bestätige riskante Schritte bewusst.\n")
@@ -271,10 +275,6 @@ async def _maybe_auto_send(page):
             return
         except Exception:
             console.print("[yellow]Konnte Senden nicht automatisch auslösen.[/yellow]")
-
-        _last_sent_text: str = ""
-        _last_sent_time: float = 0.0
-        _ECHO_COOLDOWN_SEC = 10.0  # innerhalb dieses Fensters niemals auf eigenen Text antworten
 
 
 # --- Tippen -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep the auto-responder echo protection state in module-level globals so it persists between sends

## Testing
- python -m compileall chrome_chat_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68e24c26920c832b98010a4579514987