### PR TITLE
Add version banner to CMD output

### DIFF
--- a/chrome_chat_agent.py
+++ b/chrome_chat_agent.py
@@ -28,6 +28,9 @@ except Exception:
 
 console = Console()
 
+# Versionshinweis für die CMD-Ausgabe
+AGENT_VERSION = "1.0.0"
+
 # -------------------- Konfiguration ------------------------------------------
 ASK_CONFIRM      = False  # keine Rückfragen vor Aktionen
 AUTO_SEND        = True   # nach Tippen automatisch senden (domain-spezifisch)
@@ -52,6 +55,7 @@ _last_sent_time: float = 0.0
 _ECHO_COOLDOWN_SEC = 10.0  # innerhalb dieses Fensters niemals auf eigenen Text antworten
 
 # -------------------- Transparenz-Hinweis ------------------------------------
+console.print(f"[bold green]ChatHelper CMD Version {AGENT_VERSION}[/bold green]")
 console.print("[bold red]⚠ Achtung:[/bold red] Diese Sitzung wird von einer [bold]AI[/bold] unterstützt.")
 console.print("Alle Aktionen im Chrome-Browser laufen über dieses Agent-Skript. Bitte bestätige riskante Schritte bewusst.\n")
 


### PR DESCRIPTION
## Summary
- add a version constant for the Chrome chat helper
- display the version in the CMD banner so changes are visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e25c5b9ac0832b882f5025f15b2457